### PR TITLE
Unpacking can remove one level of redirection, however this

### DIFF
--- a/Asm.hs
+++ b/Asm.hs
@@ -68,12 +68,12 @@ putOp p cmd src dst = do
 -- | Monad for executing instructions
 
 data Registers = Registers
-               { r1 :: !Double
-               , r2 :: !Double
-               , r3 :: !Double
-               , r4 :: !Double
-               , r5 :: !Double
-               , r6 :: !Double
+               { r1 :: {-# UNPACK #-} !Double
+               , r2 :: {-# UNPACK #-} !Double
+               , r3 :: {-# UNPACK #-} !Double
+               , r4 :: {-# UNPACK #-} !Double
+               , r5 :: {-# UNPACK #-} !Double
+               , r6 :: {-# UNPACK #-} !Double
                } deriving (Show)
 
 initialRs :: Registers


### PR DESCRIPTION
means that all structure (Register in our case) will be recreated
however there is no point for packing small fields, i.e.
if size of field is less or equal to the word size.
There are two compiler options that affects behaviour:
- unpack-strict-fields
- unpack-small-strict-fields

Latter is enabled by default in ghc >= 7.8
